### PR TITLE
Intermittent API call failures in OKTA SDK Resolves: OKTA-86647 Bacon: test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>okta-sdk</artifactId>
     <version>0.0.4-SNAPSHOT</version>
     <properties>
-        <httpclient.version>4.3.6</httpclient.version>
+        <httpclient.version>4.5.2</httpclient.version>
         <jackson.version>2.5.0</jackson.version>
         <joda-time.version>2.7</joda-time.version>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>

--- a/src/main/java/com/okta/sdk/framework/ApiClient.java
+++ b/src/main/java/com/okta/sdk/framework/ApiClient.java
@@ -15,6 +15,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.message.BasicHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class ApiClient {
+
+    public static final int RETRY_COUNT = 3;
 
     public static final String AFTER_CURSOR = "after";
     public static final String LIMIT = "limit";
@@ -45,18 +48,15 @@ public abstract class ApiClient {
     private AtomicReference<HttpResponse> lastHttpResponseRef = new AtomicReference<HttpResponse>();
 
     ////////////////////////////////////////////
-    // CONSTRUCTORS
+    // CONSTRUCTOR
     ////////////////////////////////////////////
 
     public ApiClient(ApiClientConfiguration config) {
-        this(HttpClientBuilder.create()
-                        .setUserAgent("OktaSDKJava_v" + Utils.getSdkVersion())
-                        .disableCookieManagement().build(),
-                config);
-    }
+        StandardHttpRequestRetryHandler requestRetryHandler = new StandardHttpRequestRetryHandler(RETRY_COUNT, true);
+        HttpClient client = HttpClientBuilder.create().setRetryHandler(requestRetryHandler)
+                .setUserAgent("OktaSDKJava_v" + Utils.getSdkVersion()).disableCookieManagement().build();
 
-    protected ApiClient(HttpClient httpClient, ApiClientConfiguration config) {
-        this.httpClient = httpClient;
+        this.httpClient = client;
         this.baseUrl = config.getBaseUrl();
         this.apiVersion = config.getApiVersion();
         this.configuration = config;


### PR DESCRIPTION
Fixed intermittent API call failures due to Apache HttpClient. Added a connection manager and retry strategy per Apache documentation.

Resolves : OKTA-86647
Primary Reviewer : @royalchan-okta @tthompson-okta 
Reviewers: @federations-okta