### PR TITLE
Added ability for createUser() to also specify groupIds that the new …

### DIFF
--- a/src/main/java/com/okta/sdk/models/users/User.java
+++ b/src/main/java/com/okta/sdk/models/users/User.java
@@ -6,6 +6,7 @@ import com.okta.sdk.framework.ApiObject;
 import com.okta.sdk.models.links.LinksUnion;
 import org.joda.time.DateTime;
 
+import java.util.List;
 import java.util.Map;
 
 public class User extends ApiObject {
@@ -62,6 +63,12 @@ public class User extends ApiObject {
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
     @JsonProperty(value = "_links")
     private Map<String, LinksUnion> links;
+
+    /**
+     * Used only for creation of new Users.  These are the groups that the new User will be immediately added to.
+     */
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
+    private List<String> groupIds;
 
     /**
      * Gets id
@@ -223,5 +230,23 @@ public class User extends ApiObject {
 
     public void setLinks(Map<String, LinksUnion> links) {
         this.links = links;
+    }
+
+    /**
+     * Used only for creation of new Users.  These are the groups that the new User will be immediately added to.
+     *
+     * @return list of group ids that new user will be added to
+     */
+    public List<String> getGroupIds() {
+        return this.groupIds;
+    }
+
+    /**
+     * Used only for creation of new Users.  These are the groups that the new User will be immediately added to.
+     *
+     * @param groupIds list of group ids that new user will be added to
+     */
+    public void setGroupIds(List<String> groupIds) {
+        this.groupIds = groupIds;
     }
 }


### PR DESCRIPTION
…user should immediately be added to.  This was done by adding the groupIds array to the User object.  This array is only read by the create user API call at present, and it is not planned that it will ever be returned in any responses.
