### PR TITLE
:bug: Service-side changes break getting AppInstance

### DIFF
--- a/src/main/java/com/okta/sdk/models/apps/Notifications.java
+++ b/src/main/java/com/okta/sdk/models/apps/Notifications.java
@@ -1,8 +1,10 @@
 package com.okta.sdk.models.apps;
 
-public class Notifications {
-    public static class Vpn {
-        public static class Network {
+import com.okta.sdk.framework.ApiObject;
+
+public class Notifications extends ApiObject {
+    public static class Vpn extends ApiObject {
+        public static class Network extends ApiObject {
             private String connection;
 
             public String getConnection() {


### PR DESCRIPTION
Problem: JSON for Vpn under Notifications changed on service side and
was no longer possible to read AppInstance objects back.

Solution: make offending data classes extend ApiObject.

Alternative Solution (not included): accept JSON with unknown
properties in **JsonApiClient**:

**src/main/java/com/okta/sdk/framework/JsonApiClient.java**:

```java
objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
```